### PR TITLE
Bump jsdom version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "BSD-3-Clause",
   "main": "lib/request.js",
   "dependencies": {
-    "jsdom": "^3.1.0",
+    "jsdom": "^7.0.1",
     "jsonld": "^0.4.0",
     "request": "^2.61.0"
   },


### PR DESCRIPTION
JSDOM was having some compile errors on my Node v4. Bumped it's version and it compiles, still successfully issuing requests too.
