### PR TITLE
Fix data type hint on file:// input

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -324,7 +324,7 @@ function _request(loc, options, callback) {
       if(error) {
         return callback(error);
       }
-      _parse(loc, options.type, data, function(err, data) {
+      _parse(loc, options.dataType, data, function(err, data) {
         callback(err, null, data);
       });
     });


### PR DESCRIPTION
This makes `jsonld-cli` work with the -t option to the format command.